### PR TITLE
feat: Use deb822 APT sources

### DIFF
--- a/.github/workflows/download-and-test-external.yml
+++ b/.github/workflows/download-and-test-external.yml
@@ -212,7 +212,14 @@ jobs:
               mkdir -p build/output/{debs,debs-beta}/extra/${i}-utils
               mkdir -p build/output/{debs,debs-beta}/extra/${i}-desktop
               # add all armbian repositories
-              echo "deb [arch=armhf,arm64,amd64,i386,riscv64 signed-by=/usr/share/keyrings/armbian.gpg] http://apt.armbian.com ${i} main ${i}-utils ${i}-desktop" | sudo tee /etc/apt/sources.list.d/armbian-${i}.list
+              cat <<- EOF | tee /etc/apt/sources.list.d/armbian-${i}.sources
+              Types: deb
+              URIs: https://apt.armbian.com
+              Suites: ${i}
+              Components: main ${i}-utils ${i}-desktop
+              Architectures: armhf arm64 amd64 i386 riscv64
+              Signed-By: /usr/share/keyrings/armbian.gpg
+              EOF
           done
 
           # update and get version
@@ -311,7 +318,7 @@ jobs:
 
       - name: Build testing repository
         run: |
-        
+
           # read config once again
           . os/external/${{ matrix.node }}.conf
           cd build
@@ -431,7 +438,14 @@ jobs:
           wget https://${URL}/armbian.key -O key
           gpg --dearmor < key | tee /usr/share/keyrings/armbian.gpg > /dev/null
           chmod go+r /usr/share/keyrings/armbian.gpg
-          echo "deb [signed-by=/usr/share/keyrings/armbian.gpg] http://${URL} $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" | tee /etc/apt/sources.list.d/armbian.list
+          cat <<- EOF | tee /etc/apt/sources.list.d/armbian.sources
+          Types: deb
+          URIs: https://${URL}
+          Suites: $RELEASE
+          Components: main ${RELEASE}-utils ${RELEASE}-desktop
+          Signed-By: /usr/share/keyrings/armbian.gpg
+          EOF
+
           apt update -y
           apt upgrade -y
 

--- a/.github/workflows/repository-status.yml
+++ b/.github/workflows/repository-status.yml
@@ -40,7 +40,14 @@ jobs:
           sudo gpg --dearmor < key | sudo tee /usr/share/keyrings/armbian.gpg > /dev/null
           sudo chmod go+r /usr/share/keyrings/armbian.gpg
           RELEASE=$(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d"=" -f2)
-          sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] http://beta.armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" | sudo tee /etc/apt/sources.list.d/armbian.list
+          cat <<- EOF | tee /etc/apt/sources.list.d/armbian.sources
+          Types: deb
+          URIs: https://beta.armbian.com
+          Suites: ${RELEASE}
+          Components: main ${RELEASE}-utils ${RELEASE}-desktop
+          Architectures: $(dpkg --print-architecture)
+          Signed-By: /usr/share/keyrings/armbian.gpg
+          EOF
           sudo apt-get update
           CURRENT=$(apt search --names-only 'linux-image-current-x86' 2> /dev/null | grep Armbian | grep -oE "(\w*[.]\w*)*" | head -1)
           EDGE=$(apt search --names-only 'linux-image-edge-x86' 2> /dev/null | grep Armbian | grep -oE "(\w*[.]\w*)*" | head -1)
@@ -48,7 +55,7 @@ jobs:
           echo "EDGE=${EDGE}" >> $GITHUB_ENV
       - name: Get runners capacity
         run: |
-          
+
           echo "ABc= $CURRENT $EDGE"
           sudo apt-get -y install datamash
           LIST=$(curl -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" -H "Accept: application/json; indent=4" \
@@ -70,7 +77,7 @@ jobs:
 
           # add smoke test success
           #gh run download --name status --repo github.com/armbian/scripts
-          #jq '.SMOKE += "'$(cat success)'%"' runners_capacity.json > tmp.json          
+          #jq '.SMOKE += "'$(cat success)'%"' runners_capacity.json > tmp.json
           #cp tmp.json runners_capacity.json
           #cat runners_capacity.json
 
@@ -82,7 +89,7 @@ jobs:
           #| xargs -n5 -d'\n' | sed -e 's/\" \"/\",\"/g' | tr -d '"' | sed "s/,/\t/g" | datamash --sort -g 5 sum 2,3 --output-delimiter=, \
           #| LC_ALL=C awk -F , -v OFS=\| '$3/=1024' | cut -d"." -f1 | sed -e 's/$/ Gb/g' | sed -e 's/^\|$/|/g' >> label.tmp
 
-          # header and footer are edited at GitHub          
+          # header and footer are edited at GitHub
           cat scripts/.github/header.inc > scripts/README.md
           echo -en "\n\n" >> scripts/README.md
           #cat label.tmp >> scripts/README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,14 @@ jobs:
           wget https://${{ inputs.url }}/armbian.key -O key
           gpg --dearmor < key | tee /usr/share/keyrings/armbian.gpg > /dev/null
           chmod go+r /usr/share/keyrings/armbian.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] http://${{ inputs.url }} $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" | tee /etc/apt/sources.list.d/armbian.list
+          cat <<- EOF | tee /etc/apt/sources.list.d/armbian.sources
+          Types: deb
+          URIs: https://${{ inputs.url }}
+          Suites: ${RELEASE}
+          Components: main ${RELEASE}-utils ${RELEASE}-desktop
+          Architectures: $(dpkg --print-architecture)
+          Signed-By: /usr/share/keyrings/armbian.gpg
+          EOF
           apt update -y
           apt upgrade -y
 

--- a/.github/workflows/testing-packages.yml
+++ b/.github/workflows/testing-packages.yml
@@ -58,7 +58,14 @@ jobs:
           wget https://${{ inputs.url }}/armbian.key -O key
           gpg --dearmor < key | tee /usr/share/keyrings/armbian.gpg > /dev/null
           chmod go+r /usr/share/keyrings/armbian.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/armbian.gpg] http://${{ inputs.url }} $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" | tee /etc/apt/sources.list.d/armbian.list
+          cat <<- EOF | tee /etc/apt/sources.list.d/armbian.sources
+          Types: deb
+          URIs: https://${{ inputs.url }}
+          Suites: ${RELEASE}
+          Components: main ${RELEASE}-utils ${RELEASE}-desktop
+          Architectures: $(dpkg --print-architecture)
+          Signed-By: /usr/share/keyrings/armbian.gpg
+          EOF
           apt update -y
           apt upgrade -y
 


### PR DESCRIPTION
> This PR and the related PRs will require discussion or RFC before merging, particularly around handling migration of existing installations.

See main PR: https://github.com/armbian/build/pull/7790

- Replace `armbian.list` with `armbian.sources`. This holds the same information in a newer format, deb822.
- Replace HTTP with HTTPS for Armbian repositories.