### PR TITLE
Also repack chromium-l10n

### DIFF
--- a/.github/workflows/download-and-test-external.yml
+++ b/.github/workflows/download-and-test-external.yml
@@ -257,7 +257,7 @@ jobs:
 
           # repack deb files
           sudo apt-get install devscripts
-          DEBS=($(sudo find "${SOURCE}"* -type f -name '*thunderbird*.deb' -o -name '*chromium-browser*.deb' -o -name '*chromium_*.deb' -o -name '*chromium-driver*.deb' -o -name '*firefox_*.deb'))
+          DEBS=($(sudo find "${SOURCE}"* -type f -name '*thunderbird*.deb' -o -name '*chromium-browser*.deb' -o -name '*chromium_*.deb' -o -name '*chromium-l10n_*.deb' -o -name '*chromium-driver*.deb' -o -name '*firefox_*.deb'))
           for d in ${DEBS[@]}; do
             BEFORE=$(deb-reversion -c ${d} -s armbian)
             #add epoch 9


### PR DESCRIPTION
chromium-l10n has a dependency:
`chromium (>= ${source:Version}), chromium (<< ${source:Version}.1~)`
So it has to get repacked together with chromium.